### PR TITLE
Decryption through systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pre-Build: Files are encrypted by external age key in repository (unencrypted wi
 
 Post-Build: Files are encrypted by external age key while in nix store
 
-Runtime: Files are stored unencrytped in `/run/user/$UID/secrets` and can be symlinked to other locations
+Runtime: Files are stored unencrypted in `/run/user/$UID/secrets` and can be symlinked to other locations
 
 ## Roadmap
 
@@ -87,7 +87,7 @@ Check out all the [options](./options.md)
 
 ## How it works
 
-On home manager build, the age-encrypted files are built into the nix store and symlinked to the provided `homage.folder` path. This is achieved through the home-manager `home.file` option. Notice that all secret files are encrypted while in the nix store. After the symlinks are finished by home-manager, the systemd units are run. Each secret has its own `oneshot` service that runs a decryption script. This works seamlessly with home-managers updating/reloading of systemd units. The script decrypts the secrets to `/run/user/$UID/secrets/` using the identities provided by `homeage.identityPaths`. It then acts on the decrypted file (changing ownership, linking, etc.). When rebooting, the decrypted files are lost as they are in the `/run` folder. Therefore, the systemd unit is wanted by `default.target` so it will run on startup.
+On home manager build, the age-encrypted files are built into the nix store and symlinked to the provided `homeage.folder` path. This is achieved through the home-manager `home.file` option. Notice that all secret files are encrypted while in the nix store. After the symlinks are finished by home-manager, the systemd units are run. Each secret has its own `oneshot` service that runs a decryption script. This works seamlessly with home-managers updating/reloading of systemd units. The script decrypts the secrets to `/run/user/$UID/secrets/` using the identities provided by `homeage.identityPaths`. It then acts on the decrypted file (changing ownership, linking, etc.). When rebooting, the decrypted files are lost as they are in the `/run` folder. Therefore, the systemd unit is wanted by `default.target` so it will run on startup.
 
 ## Acknowledgments
 

--- a/module/default.nix
+++ b/module/default.nix
@@ -72,7 +72,7 @@ let
   secretFile = types.submodule ({ config, ... }: {
     options = {
       path = mkOption {
-        description = "Path to Name to give decryption service file";
+        description = "Relative path of where the file will be saved (in secret folder and /run). .age is appended automatically to the encrypted file path.";
         type = types.str;
       };
 

--- a/options.md
+++ b/options.md
@@ -38,7 +38,13 @@
 
 **homeage.file.\<name\>**:
 
-- *Description*: Path of where the file will be saved (after the base paths). `.age` is appended automatically to the encrypted file path.
+- *Description*: Name of the service unit that decrypts the secret (`{name}-secret`)
+
+**homeage.file.\<name\>**:
+
+- *Description*: Relative path of where the file will be saved (in secret folder and `/run`). `.age` is appended automatically to the encrypted file path.
+- *Default*: none
+- *Type*: `types.str`
 
 **homeage.file.\<name\>.source**:
 


### PR DESCRIPTION
Switch from using a decryption script through a custom home manager activation to systemd services. Each secret gets its own service unit. This provides us with the reload and update capabilities built into `home-manager`. The service units are one-shot and wanted by `default.target` so they run on startup. Eliminates the need for a startup script. Inspired by: https://christine.website/blog/nixos-encrypted-secrets-2021-01-20. There are a few breaking changes:

The `homeage.file.<name>` is now the name of the service that is create (`{name}-secret`). There is a new required option, `homeage.file.<name>.path` that takes the place of the old name, it is the path where the secret is stored.

Progress:

- [x] Systemd works on my local machine (no true tests yet)
- [x] Update documentation