### PR TITLE
Implement cleanup on generation change

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -18,11 +18,11 @@ let
     ${command} ${runtimepath} ${dest}
   '')) destinations);
 
-  decryptSecret = name: { source, path, symlinks, cpOnService, mode, owner, group, ... }:
+  decryptSecret = name: { source, decryptPath, lnOnStartup, cpOnStartup, mode, owner, group, ... }:
     let
-      runtimepath = runtimeDecryptPath path;
-      linksCmds = createFiles "ln -sf" runtimepath symlinks;
-      copiesCmds = createFiles "cp -f" runtimepath cpOnService;
+      runtimepath = runtimeDecryptPath decryptPath;
+      linksCmds = createFiles "ln -sf" runtimepath lnOnStartup;
+      copiesCmds = createFiles "cp -f" runtimepath cpOnStartup;
     in
     pkgs.writeShellScriptBin "${name}-decrypt" ''
       set -euo pipefail
@@ -62,6 +62,189 @@ let
         })
     )
     cfg.file;
+
+  secretState =
+    if (cfg.file != { }) then
+      (lib.attrsets.mapAttrs'
+        (name: value:
+          lib.attrsets.nameValuePair
+            (value.path)
+            ({
+              source = value.source;
+              symlinks = value.symlinks;
+              copies = value.cpOnService;
+            })
+        )
+        cfg.file) else { };
+
+  stateFile = with builtins; toFile "homeage-state" (toJSON {
+    inherit secretState;
+    mount = cfg.mount;
+  });
+
+  statePath = "homeage/stateFile.json";
+
+  cleanupScript =
+    let
+      cleanupFunction = ''
+        homeageCleanup() {
+          # oldGenPath and newGenPath come from activation init:
+          # https://github.com/nix-community/home-manager/blob/master/modules/lib-bash/activation-init.sh
+          if [[ ! -v oldGenPath ]] ; then
+            echo "No previous generation: no cleanup needed."
+            return
+          fi
+
+          echo "Cleaning up decrypted secrets (mounted, copied, and linked)"
+
+          local oldGenFile newGenFile
+          oldGenFile="$oldGenPath/${statePath}"
+          newGenFile="$newGenPath/${statePath}"
+
+          echo $newGenFile
+
+          # Technically not possible (state always written if has secrets). Check anyway
+          if [ ! -L "$newGenFile" ] || [ ! -e "$newGenFile" ]; then
+            echo "Homeage is activated but no current state" >&2
+            return 1
+          fi
+
+          if [ ! -L "$oldGenFile" ] || [ ! -e "$oldGenFile" ] ; then
+            echo "No previous homeage state: no cleanup needed" 
+            return
+          fi
+
+
+          if [ "$(cat "$oldGenFile")" = "{}" ] ; then
+            echo "Old state has no secrets: no cleanup needed"
+            return
+          fi
+          
+          local mountPath mergedState
+          mountPath=$(getMount "$oldGenFile")
+          mergedState=$(mergeJSON "$oldGenFile" "$newGenFile")
+
+          echo "$mergedState"
+
+          local intersectedPaths
+          intersectedSecretPaths=$(intersectPath "$mergedState")
+
+          # Iterate through each intersected path
+          local secretPath secretPathB64 oldAttrs
+          local symlinks b64symlink symlink
+          local copies b64copy copy
+          for secretPathB64 in $intersectSecretsPath ; do
+              secretPath=$(echo $secretPathB64 | base64 --decode)
+              oldAttrs=$(pathAttrs "$oldGenFile" "$secretPath")
+              echo "Cleaning up secret: $secretPath"
+
+              copies=$(attrList "$oldAttrs" "copies")
+              for b64copy in $copies ; do
+                  copy=$(echo $b64copy | base64 --decode)
+                  echo "Removing copy: $copy"
+              done
+
+
+              symlinks=$(attrList "$oldAttrs" "symlinks")
+              for b64symlink in $symlinks ; do
+                  symlink=$(echo $b64symlink | base64 --decode)
+                  echo "Unlinking: $symlink"
+              done
+
+
+              echo "Removing source secret: $mountPath/$secretPath"
+          done
+        }
+      '';
+
+      jqFunctions = ''
+        PATH=$PATH:${pkgs.jq}/bin/jq
+
+        # Get mount path
+        # $1: State file
+        getMount () {
+          local result=$(jq -r '.mount' "$1")
+          echo $result
+        }
+
+        # Merge json files.
+        # $1: Old state file
+        # $2: New state file
+        mergeJSON () {
+          local result=$(jq -s '{ s1: .[0] } + { s2: .[1] }' "$1" "$2")
+          echo $result
+        }
+
+        # Get intersection of paths.
+        # $1: Merged json string
+        intersectPath () {
+          local result=$(echo $1 | jq -r '( .s1.secretState | keys ) - ( .s2.secretState | keys ) | .[] | @base64')
+          echo $result
+        }
+
+        # Get attributes of secret using the path
+        # $1: State file
+        pathAttrs () {
+          local result=$(jq --arg TP $(echo "$2") '.secretState[$TP]' "$1")
+          echo $result
+        }
+
+        # Get b64 encoded list from a secret path attribute
+        # $1: Secret attributes string
+        # $2: Attribute to extract list from
+        attrList () {
+          local result=$(echo $1 | jq -r --arg ATTR $(echo $2) '.[$ATTR] | .[] | @base64')
+          echo $result
+        }
+
+        # Get union of paths.
+        # $1: Merged json string
+        unionPath () {
+          local result=$(echo "$1" | jq '( .s1 | keys ) - (( .s1 | keys) - ( .s2 | keys ))')
+          echo $result
+        }
+
+        # Gets values of a path
+        # $1: mergeJSON result
+        # $2: path name
+        pathVals () {
+          local result=$(echo "$1" | jq --arg TP $(echo "$2") '{ p1: s1[$TP], p2: .s2[$TP] }')
+          echo $result
+        }
+
+        # Get the intersection of a path attribute
+        # $1: pathVals result
+        # $2: attribute name (either "symlinks" or "copies")
+        intersectPathAttr () {
+          local result=$(echo "$1" | jq --arg ATTR $(echo "$2") '(.p1[$ATTR]) - (.p2[$ATTR)')
+          echo $result
+        }
+      '';
+
+      cleanupHelpers = ''
+        rmRecursiveDir () {
+            # Recursively remove empty parent directories
+            echo hi
+        }
+
+        unlinkPath () {
+            # Unlink if points to source secret
+            echo hi
+        }
+
+        rmCopy () {
+          # Remove if file == source secret
+          # https://stackoverflow.com/questions/12900538/fastest-way-to-tell-if-two-files-have-the-same-contents-in-unix-linux
+          echo hi
+        }
+      '';
+    in
+    builtins.concatStringsSep "\n" [
+      jqFunctions
+      cleanupHelpers
+      cleanupFunction
+      "homeageCleanup"
+    ];
 
   # Options for a secret file
   # Based on https://github.com/ryantm/agenix/pull/58
@@ -146,14 +329,22 @@ in
     };
   };
 
-  config = mkIf (cfg.file != { }) (mkMerge [
-    {
+  config = mkMerge [
+    (mkIf (cfg.file != { }) {
       assertions = [{
         assertion = cfg.identityPaths != [ ];
         message = "secret.identityPaths must be set.";
       }];
 
       systemd.user.services = mkServices;
-    }
-  ]);
+    })
+    ({
+      home.activation.homageCleanup = hm.dag.entryAfter [ "writeBoundary" ] cleanupScript;
+
+      home.extraBuilderCommands = ''
+        mkdir -p $(dirname $out/${statePath})
+        ln -s ${stateFile} $out/${statePath}
+      '';
+    })
+  ];
 }


### PR DESCRIPTION
# homeageCleanup Overview

## Goal

Cleanup state of copies and symlinks on home manager changes (updates and rollbacks). Only way to have a non-cleaned up system is if you remove the homeage module before clearing all secrets.

## State File - DONE

Our new secrets will be transformed into the following data structure and written into the `home-manager-generation` derivation as a json file. This is so state can be accessed during activation:

```nix
{
  secretState = {
    "<path>" = {
      source = "{encrypted file path}";
      symlinks = [ ];
      copies = [ ]; # Union of cpOnActivation and cpOnService paths
    };
  };
  mount = "";
}
```

## Activation

Activation script is always run (even if no secrets are declared). This is because we might go from secrets -> no secrets. Thus secrets still need to be cleaned.

Activation occurs after `writeBoundary` because we are producing observable side effects (cleaning up files): `home.activation.homeageCleanup = hm.dag.entryAfter [ "writeBoundary" ]`.

An activation script can access the old and new generation path with `$oldGenPath` and `$newGenPath` (see [activation-init.sh](https://github.com/nix-community/home-manager/blob/2917ef23b398a22ee33fb34b5766b28728228ab1/modules/lib-bash/activation-init.sh))

## Script Process

JSON interaction is done using `jq`

1. If old generation doesn't exist skip cleanup (nothing to cleanup, first gen) - DONE
2. If old generation doesn't have a state file skip cleanup (nothing to cleanup, first gen with homeage) - DONE
3. If `oldState == {}` then no secrets have been declared (nothing to cleanup) - DONE
4. Merge `oldState` and `newState` json
5. Perform difference `oldState - newState` by path.
    1. For each path in difference, delete all symlinks and copied files. Also delete secret from `mount + {path}`
6. Perform union `oldState U newState` by path.
    1. For each secret perform difference `oldState - newState` on symlinks and copies. Delete the difference symlinks and copies
