### PR TITLE
there was typo in cpu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ While the following below is immense, its mostly just home manager flake boilerp
         inherit system;
       };
       
-      system = "x86-64_linux";
+      system = "x86_64-linux";
       username = "jd";
       stateVersion = "21.05";
     in {


### PR DESCRIPTION
typo in CPU, fixed it. there are some options still there which on new
home manager master release are deprecated.