### PR TITLE
don't rely on jq being installed in user profile

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -138,9 +138,9 @@ with lib; let
       ${pkgs.gnused}/bin/sed \
         "s/\$UID/$(id -u)/g" |
       while IFS=$"\n" read -r c; do
-        path=$(echo "$c" | jq --raw-output '.path')
-        symlinks=$(echo "$c" | jq --raw-output '.symlinks[]')
-        copies=$(echo "$c" | jq --raw-output '.copies[]')
+        path=$(echo "$c" | ${pkgs.jq}/bin/jq --raw-output '.path')
+        symlinks=$(echo "$c" | ${pkgs.jq}/bin/jq --raw-output '.symlinks[]')
+        copies=$(echo "$c" | ${pkgs.jq}/bin/jq --raw-output '.copies[]')
 
         ${cleanupSecret "[homeage] "}
       done


### PR DESCRIPTION
jq is used in activation script without absolute path, this results in command not found errors when jq is not installed in user profile