### PR TITLE
Remove obsolete jq --argfile option

### DIFF
--- a/module/default.nix
+++ b/module/default.nix
@@ -125,11 +125,11 @@ with lib; let
       ${jq} \
         --null-input \
         --compact-output \
-        --argfile old "$oldGenFile" \
+        --slurpfile old "$oldGenFile" \
         ${
       if isActivation
       then ''
-        --argfile new "$newGenFile" \
+        --slurpfile new "$newGenFile" \
         '$old - $new | .[]' |
       ''
       else ''


### PR DESCRIPTION
The **jq** option `--argfile` was deprecated for a long time and it was finally removed from **jq 1.7**, which is causing the following error in activation script:

`jq: Unknown option --argfile`

The alternative is to use `--slurpfile` option which basically behaves in a same way.

References:
- https://github.com/jqlang/jq/pull/2768
- https://github.com/jqlang/jq/releases/tag/jq-1.7